### PR TITLE
update proposed change in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var layerZIndex = (event) => { event.target.style.zIndex = '9999' }
 
 ```
 // use the `dragMethods` api to pipe in drag methods and the mixin.
-// currently using chaining, although it's possible there is a better syntax
+// currently using chaining, although a decoupled implementation of an event system would be better.
 
 import { dragMethods as d } from './src/index'
 


### PR DESCRIPTION
The debate here is between having an explicit, synchronous `api` versus using a `pubsub` pattern to listen for drag events and  


#### The chaining api
```
var dragHandler = (event) =>  drag.handleEvents(event)
  .changeEffectAllowed('none')
  .mixin(mixinFn)
```


#### A proposed `drag` listener

```
var listen = (event) => respond[event.target.id](event);

var respond = {

   div: (event) => emit('changeEffectAllowed("none")', layerZIndex);


}

```